### PR TITLE
fix: reduce memory usage in copyTree

### DIFF
--- a/internal/pkg/koreader_install.go
+++ b/internal/pkg/koreader_install.go
@@ -871,22 +871,45 @@ func copyTree(source, destination string) error {
 		if err != nil {
 			return err
 		}
+
 		rel, err := filepath.Rel(source, path)
 		if err != nil {
 			return err
 		}
+
 		target := filepath.Join(destination, rel)
+
 		if entry.IsDir() {
 			return os.MkdirAll(target, 0755)
 		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
+
 		info, err := entry.Info()
 		if err != nil {
 			return err
 		}
-		return os.WriteFile(target, data, info.Mode().Perm())
+
+		input, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer input.Close()
+
+		output, err := os.OpenFile(
+			target,
+			os.O_CREATE|os.O_TRUNC|os.O_WRONLY,
+			info.Mode().Perm(),
+		)
+		if err != nil {
+			return err
+		}
+
+		_, copyErr := io.Copy(output, input)
+		closeErr := output.Close()
+
+		if copyErr != nil {
+			return copyErr
+		}
+
+		return closeErr
 	})
 }


### PR DESCRIPTION
# Fix `copyTree` installation failures on low-RAM Kindle devices

## Summary

This PR changes the implementation of `copyTree` to copy files incrementally using `filepath.WalkDir` and `io.Copy`.

The goal is to avoid installation failures on Kindle devices with limited RAM, where the previous implementation could require too much memory when copying files.

## Problem

On Kindle devices with low available RAM, package installation could fail while copying files.

The previous `copyTree` implementation handled the copy operation in a way that could result in unnecessary memory usage. This is particularly problematic on older Kindle models with very limited system resources.

## Solution

The new implementation:

- Uses `filepath.WalkDir` to traverse the source directory.
- Creates directories as they are encountered with `os.MkdirAll`.
- Opens each source file individually.
- Opens the corresponding destination file with the original permission bits.
- Copies the file using `io.Copy`, streaming the data instead of loading the entire file into memory.
- Explicitly closes both input and output files and propagates copy/close errors.

This keeps memory usage low and makes the operation better suited to resource-constrained devices such as low-RAM Kindles.

## Implementation

```go
func copyTree(source, destination string) error {
	return filepath.WalkDir(source, func(path string, entry fs.DirEntry, err error) error {
		if err != nil {
			return err
		}

		rel, err := filepath.Rel(source, path)
		if err != nil {
			return err
		}

		target := filepath.Join(destination, rel)

		if entry.IsDir() {
			return os.MkdirAll(target, 0755)
		}

		info, err := entry.Info()
		if err != nil {
			return err
		}

		input, err := os.Open(path)
		if err != nil {
			return err
		}
		defer input.Close()

		output, err := os.OpenFile(
			target,
			os.O_CREATE|os.O_TRUNC|os.O_WRONLY,
			info.Mode().Perm(),
		)
		if err != nil {
			return err
		}

		_, copyErr := io.Copy(output, input)
		closeErr := output.Close()

		if copyErr != nil {
			return copyErr
		}

		return closeErr
	})
}
```
## Expected impact
This change reduces the memory overhead of directory copying and improves installation reliability on Kindle devices with limited RAM.

The behavior of copyTree remains unchanged from the caller's perspective.

## Testing
Tested against the installation scenario on low-RAM Kindle devices where the previous implementation could fail due to memory constraints.